### PR TITLE
Fix working memory state updates

### DIFF
--- a/Jarvis.Core/Agent.cs
+++ b/Jarvis.Core/Agent.cs
@@ -41,6 +41,7 @@ public class Agent : IAgent
     }
 
     public void Perceive(EnvironmentState environmentState) {
+        memoryManager.UpdateCurrentState(environmentState);
         var focus = focusSelector.SelectFocus(environmentState, State.Traits, State.Memory);
         State = State with { Focus = focus };
         State = State with { Memory = memoryManager.GetCurrentMemory() };

--- a/Jarvis.Core/Memory/DefaultMemoryManager.cs
+++ b/Jarvis.Core/Memory/DefaultMemoryManager.cs
@@ -19,6 +19,10 @@ public class MemoryManager : IMemoryManager
         };
     }
 
+    public void UpdateCurrentState(EnvironmentState state) {
+        _working = _working with { CurrentState = state };
+    }
+
     public void Consolidate() { /* Placeholder: logic for abstracting concepts from episodes */ }
     public void Decay() { /* Placeholder: decay old episodes, manage memory size */ }
     public AgentMemory GetCurrentMemory() =>

--- a/Jarvis.Core/Memory/IMemoryManager.cs
+++ b/Jarvis.Core/Memory/IMemoryManager.cs
@@ -1,8 +1,11 @@
-﻿namespace Jarvis.Core.Memory;
+using Jarvis.Environment;
+
+namespace Jarvis.Core.Memory;
 
 public interface IMemoryManager
 {
     void StoreEpisode(Episode episode);
+    void UpdateCurrentState(EnvironmentState state);
     void Consolidate();
     void Decay();
     AgentMemory GetCurrentMemory();


### PR DESCRIPTION
## Summary
- track the current environment state in the memory manager
- update Agent to pass new state to the memory manager

## Testing
- `dotnet test` *(fails: `dotnet` not found)*